### PR TITLE
Add Collapsible Action Menu To Space-Styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Custom stylings.
 
 - [Invisible header](./styles/InvisibleTopBar.md) Hides the top bar, visually merging it with the content pane.
 - [Obsidian](./styles/Obisidian.md) Obsidian like color schema. By @whede92.
+- [CollapsibleMenu](./styles/Obisidian.md)Mobile friendly collapsible vertical ActionMenu. By @MrRed.
 
 ## Settings
 Snippets & configurations for `SETTINGS.md`.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Custom stylings.
 
 - [Invisible header](./styles/InvisibleTopBar.md) Hides the top bar, visually merging it with the content pane.
 - [Obsidian](./styles/Obisidian.md) Obsidian like color schema. By @whede92.
-- [CollapsibleMenu](./styles/Obisidian.md)Mobile friendly collapsible vertical ActionMenu. By @MrRed.
+- [CollapsibleMenu](./styles/CollapsibleActionMenu.md) Mobile friendly collapsible vertical ActionMenu. By @MrRed.
 
 ## Settings
 Snippets & configurations for `SETTINGS.md`.

--- a/styles/CollapsibleActionMenu.md
+++ b/styles/CollapsibleActionMenu.md
@@ -1,5 +1,4 @@
-This Will make the ActionMenu collapsible for Mobile Devices
-
+This will make the ActionMenu collapsible for Mobile Devices
 
 ```space-style
 /*Mobile Collabsible Menu*/
@@ -37,4 +36,17 @@ This Will make the ActionMenu collapsible for Mobile Devices
   }
 }
 
+```
+
+For this to work properly you also need to add an empty action button as the first action button.
+I also recommend hiding the Sync and Edit buttons in the space-config:
+
+```space-config
+hideSyncButton: true
+hideEditButton: true
+
+actionButtons:
+- icon: more-vertical
+  command: "{[]}"
+  description: Open Tool Menu
 ```

--- a/styles/CollapsibleActionMenu.md
+++ b/styles/CollapsibleActionMenu.md
@@ -1,3 +1,6 @@
+This Will make the ActionMenu collapsible for Mobile Devices
+
+
 ```space-style
 /*Mobile Collabsible Menu*/
 @media only screen and (max-width: 600px) {

--- a/styles/CollapsibleActionMenu.md
+++ b/styles/CollapsibleActionMenu.md
@@ -1,0 +1,37 @@
+```space-style
+/*Mobile Collabsible Menu*/
+@media only screen and (max-width: 600px) {
+  #sb-top .sb-actions {
+    position: fixed;
+    border-radius: 5px;
+    border: 1px solid #444 ;
+    top: 12px;
+    right: 20px;
+    width: 2.4rem;  /* Collapsed width */
+    background: rgba(var(--root-background-color),0));
+    backdrop-filter: blur(15px); /* tinted glass-like blur for the background */
+    overflow: hidden;  /* Hide overflowing content */
+    flex-direction: column; 
+    align-items: center;
+    z-index: 10; /* Ensure the buttons stay on top */
+  }
+  /* Button styling */
+  .sb-actions button:not(.sb-code-copy-button) {
+    display: block;
+    height: 1.4rem; /* 1.4 */
+    text-align: center;
+    margin: 4px 0;
+    padding: 0 0;
+  }
+
+  /* Hide all buttons except the last one */
+  .sb-actions a:not(:first-of-type) {
+    display: none;   
+  }
+  /* Show all buttons when hovering */
+  #sb-top .sb-actions:hover a {
+     display: block;
+  }
+}
+
+```


### PR DESCRIPTION
This will change the Action Menu to a Mobile Friendly Vertical & Collapsible. 

Like described in this post:

https://community.silverbullet.md/t/collapsible-vertical-action-menu-for-mobilescreens-but-not-only/1552

Here is a preview of the menu:
![](https://community.silverbullet.md/uploads/default/original/1X/da860af35e8db75bc2c30622ce2d782ea233b427.png)
